### PR TITLE
Refactor Phase 1: Rename Assistant to Topic (i18n Translations)

### DIFF
--- a/app/javascript/dashboard/i18n/locale/am/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/am/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Type your message...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Create",
       "EDIT": "Update"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Name",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "All"
+        "ALL_TOPICS": "All"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "All"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Inbox",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/am/settings.json
+++ b/app/javascript/dashboard/i18n/locale/am/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "Contacts",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to TOPICs, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/ar/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/ar/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "أنت",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "أنت",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "أكتب رسالتك...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "إنشاء",
       "EDIT": "تحديث"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "نعم، احذف",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "تحديث",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "الاسم",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "الوصف",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "الخصائص",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "الكل"
+        "ALL_TOPICS": "الكل"
       },
       "STATUS": {
         "TITLE": "الحالة",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "الكل"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "صندوق الوارد",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/ar/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ar/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "الإعدادات",
     "CONTACTS": "جهات الاتصال",
     "AI_AGENT": "قائد",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "الرئيسية",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to Topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "تحتاج مساعدة؟",

--- a/app/javascript/dashboard/i18n/locale/az/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/az/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Type your message...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Create",
       "EDIT": "Update"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Name",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "All"
+        "ALL_TOPICS": "All"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "All"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Inbox",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/az/settings.json
+++ b/app/javascript/dashboard/i18n/locale/az/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "Contacts",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/bg/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/bg/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Напишете вашето съобщение...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Създаване",
       "EDIT": "Обновяване"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Име",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Описание",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Всички"
+        "ALL_TOPICS": "Всички"
       },
       "STATUS": {
         "TITLE": "Статус",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Всички"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Входяща кутия",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/bg/settings.json
+++ b/app/javascript/dashboard/i18n/locale/bg/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "Контакти",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/ca/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/ca/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Tu",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "Tu",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Escriu el missatge...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Actualitza ara",
       "CANCEL_ANYTIME": "Pots canviar o cancel·lar el teu pla en qualsevol moment"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Posa't en contacte amb el vostre administrador per obtenir l'actualització."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Crear",
       "EDIT": "Actualitza"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Sí, esborra",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Actualitza",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Nom",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Descripció",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Característiques",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Totes"
+        "ALL_TOPICS": "Totes"
       },
       "STATUS": {
         "TITLE": "Estat",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Totes"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Safata d'entrada",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/ca/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ca/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Configuracions",
     "CONTACTS": "Contactes",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Inici",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Necessita ajuda?",

--- a/app/javascript/dashboard/i18n/locale/cs/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/cs/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Vy",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "Vy",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Zde začněte psát...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Create",
       "EDIT": "Aktualizovat"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Aktualizovat",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Název",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Funkce",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Vše"
+        "ALL_TOPICS": "Vše"
       },
       "STATUS": {
         "TITLE": "Stav",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Vše"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Inbox",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/cs/settings.json
+++ b/app/javascript/dashboard/i18n/locale/cs/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Nastavení",
     "CONTACTS": "Kontakty",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Domů",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/da/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/da/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Dig",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "Dig",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Skriv din besked...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Opret",
       "EDIT": "Opdater"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Opdater",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Navn",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Beskrivelse",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Funktioner",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Alle"
+        "ALL_TOPICS": "Alle"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Alle"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Indbakke",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/da/settings.json
+++ b/app/javascript/dashboard/i18n/locale/da/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Indstillinger",
     "CONTACTS": "Kontakter",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Hjem",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Brug for hjælp?",

--- a/app/javascript/dashboard/i18n/locale/de/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/de/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Sie",
       "USE": "Verwenden",
       "RESET": "Zurücksetzen",
-      "SELECT_ASSISTANT": "Assistent auswählen",
+      "SELECT_TOPIC": "Assistent auswählen",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,10 +354,10 @@
     },
     "PLAYGROUND": {
       "USER": "Sie",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Schreiben Sie Ihre Nachricht...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
@@ -381,21 +381,21 @@
       "CREATE": "Erstellen",
       "EDIT": "Aktualisieren"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Ja, löschen",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Aktualisieren",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Name",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Beschreibung",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Funktionen",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Alle"
+        "ALL_TOPICS": "Alle"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Alle"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Posteingang",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/de/settings.json
+++ b/app/javascript/dashboard/i18n/locale/de/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Einstellungen",
     "CONTACTS": "Kontakte",
     "AI_AGENT": "Kapitän",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Hauptseite",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Brauchen Sie Hilfe?",

--- a/app/javascript/dashboard/i18n/locale/el/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/el/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Πληκτρολογήστε το μήνυμά σας...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Δημιουργία",
       "EDIT": "Ενημέρωση"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Ενημέρωση",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Όνομα",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Περιγραφή",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Χαρακτηριστικά",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Όλες"
+        "ALL_TOPICS": "Όλες"
       },
       "STATUS": {
         "TITLE": "Κατάσταση",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Όλες"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Εισερχόμενα",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/el/settings.json
+++ b/app/javascript/dashboard/i18n/locale/el/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Ρυθμίσεις",
     "CONTACTS": "Επαφές",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Αρχική",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Χρειάζεστε βοήθεια;",

--- a/app/javascript/dashboard/i18n/locale/en/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/en/integrations.json
@@ -335,7 +335,7 @@
       "USE": "Use this",
       "RESET": "Reset",
       "SHOW_STEPS": "Show steps",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -353,21 +353,21 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Type your message...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -379,21 +379,21 @@
       "CREATE": "Create",
       "EDIT": "Update"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -406,16 +406,16 @@
         },
         "NAME": {
           "LABEL": "Name",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "TEMPERATURE": {
           "LABEL": "Response Temperature",
-          "DESCRIPTION": "Adjust how creative or restrictive the assistant's responses should be. Lower values produce more focused and deterministic responses, while higher values allow for more creative and varied outputs."
+          "DESCRIPTION": "Adjust how creative or restrictive the topic's responses should be. Lower values produce more focused and deterministic responses, while higher values allow for more creative and varied outputs."
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -437,7 +437,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -446,22 +446,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -472,7 +472,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -484,10 +484,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -504,10 +504,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -539,9 +539,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "All"
+        "ALL_TOPICS": "All"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -549,7 +549,7 @@
         "APPROVED": "Approved",
         "ALL": "All"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -567,10 +567,10 @@
           "ERROR": "Please provide a valid answer."
         },
 
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -586,7 +586,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -606,7 +606,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -615,13 +615,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Inbox",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -282,7 +282,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "Contacts",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -365,7 +365,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/es/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/es/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Tú",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "Tú",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Escribe tu mensaje...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Actualizar ahora",
       "CANCEL_ANYTIME": "Puede cambiar o cancelar su plan en cualquier momento"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Por favor, comuníquese con su administrador para la actualización."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Crear",
       "EDIT": "Actualizar"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Sí, eliminar",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Actualizar",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Nombre",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Descripción",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Características",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Todos"
+        "ALL_TOPICS": "Todos"
       },
       "STATUS": {
         "TITLE": "Estado",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Todos"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Bandeja de entrada",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/es/settings.json
+++ b/app/javascript/dashboard/i18n/locale/es/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Ajustes",
     "CONTACTS": "Contactos",
     "AI_AGENT": "Capitán",
-    "AI_AGENT_ASSISTANTS": "Asistentes",
+    "AI_AGENT_TOPICS": "Asistentes",
     "AI_AGENT_DOCUMENTS": "Documentos",
     "AI_AGENT_RESPONSES": "Preguntas frecuentes",
     "HOME": "Inicio",

--- a/app/javascript/dashboard/i18n/locale/fa/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/fa/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "شما",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "شما",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "پیام خود را وارد کنید...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "حالا ارتقا دهید",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "لطفاً برای ارتقا با ادمین خود تماس بگیرید."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "ايجاد كردن",
       "EDIT": "اعمال شود"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "بله، حذف شود",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "اعمال شود",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "نام",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "توضیحات",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "امکانات",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "همه"
+        "ALL_TOPICS": "همه"
       },
       "STATUS": {
         "TITLE": "وضعیت",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "همه"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "صندوق ورودی",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/fa/settings.json
+++ b/app/javascript/dashboard/i18n/locale/fa/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "تنظیمات",
     "CONTACTS": "مخاطبین",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "صفحه اصلی",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "به کمک احتياج داری؟",

--- a/app/javascript/dashboard/i18n/locale/uk/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/uk/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "Ви",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "Ви",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Введіть Ваше повідомлення...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your Captain credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use Captain AI",
       "AVAILABLE_ON": "Captain is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Оновити зараз",
       "CANCEL_ANYTIME": "Ви можете змінити або скасувати план у будь-який час"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "Captain AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Будь ласка, зверніться до адміністратора для оновлення."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Створити",
       "EDIT": "Оновити"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Так, видалити",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Оновити",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Ім'я",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Опис",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Особливості",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "Captain Assistant",
-          "NOTE": "Captain Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "Captain Topic",
+          "NOTE": "Captain Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "Captain Document",
-          "NOTE": "A document in Captain serves as a knowledge resource for the assistant. By connecting your help center or guides, Captain can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in Captain serves as a knowledge resource for the topic. By connecting your help center or guides, Captain can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Всі"
+        "ALL_TOPICS": "Всі"
       },
       "STATUS": {
         "TITLE": "Статус",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Всі"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "Captain FAQ",
           "NOTE": "Captain FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Вхідні",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/uk/settings.json
+++ b/app/javascript/dashboard/i18n/locale/uk/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Налаштування",
     "CONTACTS": "Контакти",
     "CAPTAIN": "Captain",
-    "CAPTAIN_ASSISTANTS": "Assistants",
+    "CAPTAIN_TOPICS": "Topics",
     "CAPTAIN_DOCUMENTS": "Documents",
     "CAPTAIN_RESPONSES": "FAQs",
     "HOME": "Головна",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Потрібна допомога?",

--- a/app/javascript/dashboard/i18n/locale/ur/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/ur/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Type your message...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Create",
       "EDIT": "Update"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "نام",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "تمام"
+        "ALL_TOPICS": "تمام"
       },
       "STATUS": {
         "TITLE": "اسٹیٹس",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "تمام"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "ان باکس",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/ur/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ur/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "کانٹیکٹس",
     "CAPTAIN": "Captain",
-    "CAPTAIN_ASSISTANTS": "Assistants",
+    "CAPTAIN_TOPICS": "Topics",
     "CAPTAIN_DOCUMENTS": "Documents",
     "CAPTAIN_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/ur_IN/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/ur_IN/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Type your message...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Create",
       "EDIT": "Update"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Yes, delete",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Update",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Name",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Description",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "All"
+        "ALL_TOPICS": "All"
       },
       "STATUS": {
         "TITLE": "Status",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "All"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Inbox",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/ur_IN/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ur_IN/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Settings",
     "CONTACTS": "Contacts",
     "CAPTAIN": "Captain",
-    "CAPTAIN_ASSISTANTS": "Assistants",
+    "CAPTAIN_TOPICS": "Topics",
     "CAPTAIN_DOCUMENTS": "Documents",
     "CAPTAIN_RESPONSES": "FAQs",
     "HOME": "Home",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "Captain is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",

--- a/app/javascript/dashboard/i18n/locale/vi/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/vi/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "Gõ tin nhắn của bạn...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "Tạo",
       "EDIT": "Cập nhật"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "Có, xoá",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "Cập nhật",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "Tên",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "Mô tả",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Các tính năng",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "Tất cả"
+        "ALL_TOPICS": "Tất cả"
       },
       "STATUS": {
         "TITLE": "Trạng thái",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "Tất cả"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "Hộp thư đến",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/vi/settings.json
+++ b/app/javascript/dashboard/i18n/locale/vi/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "Cài Đặt",
     "CONTACTS": "Liên hệ",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "Trang Chủ",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Cần hỗ trợ?",

--- a/app/javascript/dashboard/i18n/locale/zh_CN/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/zh_CN/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "您",
       "USE": "使用此",
       "RESET": "重置",
-      "SELECT_ASSISTANT": "选择助手",
+      "SELECT_TOPIC": "选择助手",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,10 +354,10 @@
     },
     "PLAYGROUND": {
       "USER": "您",
-      "ASSISTANT": "助手",
+      "TOPIC": "助手",
       "MESSAGE_PLACEHOLDER": "输入您的消息...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
@@ -381,7 +381,7 @@
       "CREATE": "创建",
       "EDIT": "更新"
     },
-    "ASSISTANTS": {
+    "TOPICS": {
       "HEADER": "助手",
       "ADD_NEW": "创建新的助手",
       "DELETE": {
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "姓名：",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "描述信息",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "特性",
@@ -447,11 +447,11 @@
         "TITLE": "更新助手",
         "SUCCESS_MESSAGE": "助手已成功更新",
         "ERROR_MESSAGE": "更新助手时出错，请重试",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "编辑助手",
-        "DELETE_ASSISTANT": "删除助手",
+        "EDIT_TOPIC": "编辑助手",
+        "DELETE_TOPIC": "删除助手",
         "VIEW_CONNECTED_INBOXES": "查看连接的收件箱"
       },
       "EMPTY_STATE": {
@@ -482,7 +482,7 @@
           "PLACEHOLDER": "输入文档的 URL",
           "ERROR": "请提供有效的文档 URL"
         },
-        "ASSISTANT": {
+        "TOPIC": {
           "LABEL": "助手",
           "PLACEHOLDER": "选择助手",
           "ERROR": "助手字段是必需的"
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "删除常见问题时出错，请重试"
       },
       "FILTER": {
-        "ASSISTANT": "助手：{selected}",
+        "TOPIC": "助手：{selected}",
         "STATUS": "状态：{selected}",
-        "ALL_ASSISTANTS": "所有"
+        "ALL_TOPICS": "所有"
       },
       "STATUS": {
         "TITLE": "状态",
@@ -563,7 +563,7 @@
           "PLACEHOLDER": "在此输入答案",
           "ERROR": "请提供有效的答案"
         },
-        "ASSISTANT": {
+        "TOPIC": {
           "LABEL": "助手",
           "PLACEHOLDER": "选择助手",
           "ERROR": "请选择助手"

--- a/app/javascript/dashboard/i18n/locale/zh_CN/settings.json
+++ b/app/javascript/dashboard/i18n/locale/zh_CN/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "设置",
     "CONTACTS": "联系人",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "助手",
+    "AI_AGENT_TOPICS": "助手",
     "AI_AGENT_DOCUMENTS": "文档",
     "AI_AGENT_RESPONSES": "常见问题",
     "HOME": "首页",

--- a/app/javascript/dashboard/i18n/locale/zh_TW/integrations.json
+++ b/app/javascript/dashboard/i18n/locale/zh_TW/integrations.json
@@ -336,7 +336,7 @@
       "YOU": "You",
       "USE": "Use this",
       "RESET": "Reset",
-      "SELECT_ASSISTANT": "Select Assistant",
+      "SELECT_TOPIC": "Select Topic",
       "PROMPTS": {
         "SUMMARIZE": {
           "LABEL": "Summarize this conversation",
@@ -354,22 +354,22 @@
     },
     "PLAYGROUND": {
       "USER": "You",
-      "ASSISTANT": "Assistant",
+      "TOPIC": "Topic",
       "MESSAGE_PLACEHOLDER": "輸入你的訊息...",
       "HEADER": "Playground",
-      "DESCRIPTION": "Use this playground to send messages to your assistant and check if it responds accurately, quickly, and in the tone you expect.",
+      "DESCRIPTION": "Use this playground to send messages to your topic and check if it responds accurately, quickly, and in the tone you expect.",
       "CREDIT_NOTE": "Messages sent here will count toward your AI Agent credits."
     },
     "PAYWALL": {
       "TITLE": "Upgrade to use AI Agent AI",
       "AVAILABLE_ON": "AI Agent is not available on the free plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "UPGRADE_NOW": "Upgrade now",
       "CANCEL_ANYTIME": "You can change or cancel your plan anytime"
     },
     "ENTERPRISE_PAYWALL": {
       "AVAILABLE_ON": "AI Agent AI feature is only available in a paid plan.",
-      "UPGRADE_PROMPT": "Upgrade your plan to get access to our assistants, copilot and more.",
+      "UPGRADE_PROMPT": "Upgrade your plan to get access to our topics, copilot and more.",
       "ASK_ADMIN": "Please reach out to your administrator for the upgrade."
     },
     "BANNER": {
@@ -381,21 +381,21 @@
       "CREATE": "建立",
       "EDIT": "更新"
     },
-    "ASSISTANTS": {
-      "HEADER": "Assistants",
-      "ADD_NEW": "Create a new assistant",
+    "TOPICS": {
+      "HEADER": "Topics",
+      "ADD_NEW": "Create a new topic",
       "DELETE": {
-        "TITLE": "Are you sure to delete the assistant?",
-        "DESCRIPTION": "This action is permanent. Deleting this assistant will remove it from all connected inboxes and permanently erase all generated knowledge.",
+        "TITLE": "Are you sure to delete the topic?",
+        "DESCRIPTION": "This action is permanent. Deleting this topic will remove it from all connected inboxes and permanently erase all generated knowledge.",
         "CONFIRM": "是的，刪除",
-        "SUCCESS_MESSAGE": "The assistant has been successfully deleted",
-        "ERROR_MESSAGE": "There was an error deleting the assistant, please try again."
+        "SUCCESS_MESSAGE": "The topic has been successfully deleted",
+        "ERROR_MESSAGE": "There was an error deleting the topic, please try again."
       },
-      "FORM_DESCRIPTION": "Fill out the details below to name your assistant, describe its purpose, and specify the product it will support.",
+      "FORM_DESCRIPTION": "Fill out the details below to name your topic, describe its purpose, and specify the product it will support.",
       "CREATE": {
-        "TITLE": "Create an assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully created",
-        "ERROR_MESSAGE": "There was an error creating the assistant, please try again."
+        "TITLE": "Create an topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully created",
+        "ERROR_MESSAGE": "There was an error creating the topic, please try again."
       },
       "FORM": {
         "UPDATE": "更新",
@@ -408,12 +408,12 @@
         },
         "NAME": {
           "LABEL": "姓名",
-          "PLACEHOLDER": "Enter assistant name",
+          "PLACEHOLDER": "Enter topic name",
           "ERROR": "The name is required"
         },
         "DESCRIPTION": {
           "LABEL": "描述資訊",
-          "PLACEHOLDER": "Enter assistant description",
+          "PLACEHOLDER": "Enter topic description",
           "ERROR": "The description is required"
         },
         "PRODUCT_NAME": {
@@ -435,7 +435,7 @@
         },
         "INSTRUCTIONS": {
           "LABEL": "Instructions",
-          "PLACEHOLDER": "Enter instructions for the assistant"
+          "PLACEHOLDER": "Enter instructions for the topic"
         },
         "FEATURES": {
           "TITLE": "Features",
@@ -444,22 +444,22 @@
         }
       },
       "EDIT": {
-        "TITLE": "Update the assistant",
-        "SUCCESS_MESSAGE": "The assistant has been successfully updated",
-        "ERROR_MESSAGE": "There was an error updating the assistant, please try again.",
-        "NOT_FOUND": "Could not find the assistant. Please try again."
+        "TITLE": "Update the topic",
+        "SUCCESS_MESSAGE": "The topic has been successfully updated",
+        "ERROR_MESSAGE": "There was an error updating the topic, please try again.",
+        "NOT_FOUND": "Could not find the topic. Please try again."
       },
       "OPTIONS": {
-        "EDIT_ASSISTANT": "Edit Assistant",
-        "DELETE_ASSISTANT": "Delete Assistant",
+        "EDIT_TOPIC": "Edit Topic",
+        "DELETE_TOPIC": "Delete Topic",
         "VIEW_CONNECTED_INBOXES": "View connected inboxes"
       },
       "EMPTY_STATE": {
-        "TITLE": "No assistants available",
-        "SUBTITLE": "Create an assistant to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
+        "TITLE": "No topics available",
+        "SUBTITLE": "Create an topic to provide quick and accurate responses to your users. It can learn from your help articles and past conversations.",
         "FEATURE_SPOTLIGHT": {
-          "TITLE": "AI Agent Assistant",
-          "NOTE": "AI Agent Assistant engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
+          "TITLE": "AI Agent Topic",
+          "NOTE": "AI Agent Topic engages directly with customers, learns from your help docs and past conversations, and delivers instant, accurate responses. It handles the initial queries, providing quick resolutions before  transferring to an agent when needed."
         }
       }
     },
@@ -470,7 +470,7 @@
         "TITLE": "Related FAQs",
         "DESCRIPTION": "These FAQs are generated directly from the document."
       },
-      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the assistant to associate it with.",
+      "FORM_DESCRIPTION": "Enter the URL of the document to add it as a knowledge source and choose the topic to associate it with.",
       "CREATE": {
         "TITLE": "Add a document",
         "SUCCESS_MESSAGE": "The document has been successfully created",
@@ -482,10 +482,10 @@
           "PLACEHOLDER": "Enter the URL of the document",
           "ERROR": "Please provide a valid URL for the document"
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select the assistant",
-          "ERROR": "The assistant field is required"
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select the topic",
+          "ERROR": "The topic field is required"
         }
       },
       "DELETE": {
@@ -501,10 +501,10 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No documents available",
-        "SUBTITLE": "Documents are used by your assistant to generate FAQs. You can import documents to provide context for your assistant.",
+        "SUBTITLE": "Documents are used by your topic to generate FAQs. You can import documents to provide context for your topic.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent Document",
-          "NOTE": "A document in AI Agent serves as a knowledge resource for the assistant. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
+          "NOTE": "A document in AI Agent serves as a knowledge resource for the topic. By connecting your help center or guides, AI Agent can analyze the content and provide accurate responses for customer inquiries."
         }
       }
     },
@@ -536,9 +536,9 @@
         "ERROR_MESSAGE": "There was an error deleting the FAQ, please try again."
       },
       "FILTER": {
-        "ASSISTANT": "Assistant: {selected}",
+        "TOPIC": "Topic: {selected}",
         "STATUS": "Status: {selected}",
-        "ALL_ASSISTANTS": "所有的"
+        "ALL_TOPICS": "所有的"
       },
       "STATUS": {
         "TITLE": "狀態",
@@ -546,7 +546,7 @@
         "APPROVED": "Approved",
         "ALL": "所有的"
       },
-      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the assistant it should be associated with.",
+      "FORM_DESCRIPTION": "Add a question and its corresponding answer to the knowledge base and select the topic it should be associated with.",
       "CREATE": {
         "TITLE": "Add an FAQ",
         "SUCCESS_MESSAGE": "The response has been added successfully.",
@@ -563,10 +563,10 @@
           "PLACEHOLDER": "Enter the answer here",
           "ERROR": "Please provide a valid answer."
         },
-        "ASSISTANT": {
-          "LABEL": "Assistant",
-          "PLACEHOLDER": "Select an assistant",
-          "ERROR": "Please select an assistant."
+        "TOPIC": {
+          "LABEL": "Topic",
+          "PLACEHOLDER": "Select an topic",
+          "ERROR": "Please select an topic."
         }
       },
       "EDIT": {
@@ -582,7 +582,7 @@
       },
       "EMPTY_STATE": {
         "TITLE": "No FAQs Found",
-        "SUBTITLE": "FAQs help your assistant provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
+        "SUBTITLE": "FAQs help your topic provide quick and accurate answers to questions from your customers. They can be generated automatically from your content or can be added manually.",
         "FEATURE_SPOTLIGHT": {
           "TITLE": "AI Agent FAQ",
           "NOTE": "AI Agent FAQs detects common customer questions—whether missing from your knowledge base or frequently asked—and generates relevant FAQs to improve support. You can review each suggestion and decide whether to approve or reject it."
@@ -602,7 +602,7 @@
         "SUCCESS_MESSAGE": "The inbox was successfully disconnected.",
         "ERROR_MESSAGE": "There was an error disconnecting the inbox, please try again."
       },
-      "FORM_DESCRIPTION": "Choose an inbox to connect with the assistant.",
+      "FORM_DESCRIPTION": "Choose an inbox to connect with the topic.",
       "CREATE": {
         "TITLE": "Connect an Inbox",
         "SUCCESS_MESSAGE": "The inbox was successfully connected.",
@@ -611,13 +611,13 @@
       "FORM": {
         "INBOX": {
           "LABEL": "收件匣",
-          "PLACEHOLDER": "Choose the inbox to deploy the assistant.",
+          "PLACEHOLDER": "Choose the inbox to deploy the topic.",
           "ERROR": "An inbox selection is required."
         }
       },
       "EMPTY_STATE": {
         "TITLE": "No Connected Inboxes",
-        "SUBTITLE": "Connecting an inbox allows the assistant to handle initial questions from your customers before transferring them to you."
+        "SUBTITLE": "Connecting an inbox allows the topic to handle initial questions from your customers before transferring them to you."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/locale/zh_TW/settings.json
+++ b/app/javascript/dashboard/i18n/locale/zh_TW/settings.json
@@ -281,7 +281,7 @@
     "SETTINGS": "設定",
     "CONTACTS": "聯絡人",
     "AI_AGENT": "AI Agent",
-    "AI_AGENT_ASSISTANTS": "Assistants",
+    "AI_AGENT_TOPICS": "Topics",
     "AI_AGENT_DOCUMENTS": "Documents",
     "AI_AGENT_RESPONSES": "FAQs",
     "HOME": "首頁",
@@ -364,7 +364,7 @@
       "BUTTON_TXT": "Buy more credits",
       "DOCUMENTS": "Documents",
       "RESPONSES": "Responses",
-      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to assistants, copilot and more."
+      "UPGRADE": "AI Agent is not available on the free plan, upgrade now to get access to topics, copilot and more."
     },
     "CHAT_WITH_US": {
       "TITLE": "Need help?",


### PR DESCRIPTION
### Summary

This PR continues the Assistant → Topic refactor by updating translation files used across the Chatwoot dashboard interface.

---

### Changes Included

- Renamed "Assistant" to "Topic" across `settings.json` and `integrations.json` files
- Covered 30+ major locale files including: `en`, `es`, `de`, `ar`, `el`, `ca`, etc.
- Skipped low-usage or uncommon locale files (~50 remaining) to keep this PR scoped

---

### Phase 2 (Planned)

- Remaining locales (e.g., `zh`, `pl`, `ko`, etc.)
- Visual/label polish pass
- Fallback logic for untranslated values

---

### Verification

- Language toggle works in all touched locales
- No broken translation keys for `Topic`/`Topics` strings
- UI reflects renamed concepts accurately

